### PR TITLE
feat(deps)!: upgrade to Go 1.17 and golanci-lint 1.64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          version: v1.43
+          go-version-file: 'go.mod'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64
         env:
           VERBOSE: "true"
 
@@ -19,34 +22,22 @@ jobs:
     name: Tidy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.15
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: 'go.mod'
       - name: Check if mods are tidy
         run: make check-tidy
 
   benchmark:
     name: Benchmarks
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
+    if: github.ref != 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.15
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: 'go.mod'
       - name: Run benchmarks
         run: make bench | tee output.raw
       - name: Fix benchmark names
@@ -67,18 +58,12 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.15
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: 'go.mod'
       - name: Publish coverage
-        uses: paambaati/codeclimate-action@v2.7.4
+        uses: paambaati/codeclimate-action@v9
         env:
           VERBOSE: "true"
           GOMAXPROCS: 4
@@ -92,17 +77,22 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version:
+          - "1.17"
+          - "1.18"
+          - "1.19"
+          - "1.20"
+          - "1.21"
+          - "1.22"
+          - "1.23"
+          - "1.24"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.15
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version: ${{ matrix.go-version }}
       - name: Run tests
         run: make test
         env:
@@ -111,18 +101,12 @@ jobs:
   benchmark-store:
     name: Store benchmarks
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.15
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: 'go.mod'
       - name: Run benchmarks
         run: make bench | tee output.raw
       - name: Fix benchmark names

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,18 +4,13 @@ linters-settings:
     statements: 150
   gocyclo:
     min-complexity: 20
-  golint:
-    min-confidence: 0
   govet:
-    check-shadowing: true
     enable-all: true
     disable:
       - fieldalignment
   lll:
     line-length: 80
     tab-width: 4
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
 
@@ -24,13 +19,11 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
-    - depguard
+    - copyloopvar
     - durationcheck
     - errcheck
     - errorlint
     - exhaustive
-    - exportloopref
     - funlen
     - gochecknoinits
     - goconst
@@ -58,12 +51,10 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - wastedassign
     - whitespace
 

--- a/Makefile
+++ b/Makefile
@@ -34,23 +34,19 @@ SHELL := env \
 # Tools
 #
 
-TOOLS += $(TOOLDIR)/gobin
-$(TOOLDIR)/gobin:
-	GO111MODULE=off go get -u github.com/myitcv/gobin
-
 # external tool
 define tool # 1: binary-name, 2: go-import-path
 TOOLS += $(TOOLDIR)/$(1)
 
-$(TOOLDIR)/$(1): $(TOOLDIR)/gobin Makefile
-	gobin $(V) "$(2)"
+$(TOOLDIR)/$(1): Makefile
+	GOBIN="$(CURDIR)/$(TOOLDIR)" go install "$(2)"
 endef
 
-$(eval $(call tool,godoc,golang.org/x/tools/cmd/godoc))
-$(eval $(call tool,gofumpt,mvdan.cc/gofumpt))
-$(eval $(call tool,goimports,golang.org/x/tools/cmd/goimports))
-$(eval $(call tool,golangci-lint,github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43))
-$(eval $(call tool,gomod,github.com/Helcaraxan/gomod))
+$(eval $(call tool,godoc,golang.org/x/tools/cmd/godoc@latest))
+$(eval $(call tool,gofumpt,mvdan.cc/gofumpt@latest))
+$(eval $(call tool,goimports,golang.org/x/tools/cmd/goimports@latest))
+$(eval $(call tool,golangci-lint,github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64))
+$(eval $(call tool,gomod,github.com/Helcaraxan/gomod@latest))
 
 .PHONY: tools
 tools: $(TOOLS)
@@ -158,20 +154,3 @@ check-tidy:
 docs: $(TOOLDIR)/godoc
 	$(info serviing docs on http://127.0.0.1:6060/pkg/$(GOMODNAME)/)
 	@godoc -http=127.0.0.1:6060
-
-#
-# Release
-#
-
-.PHONY: new-version
-new-version: check-npx
-	npx standard-version
-
-.PHONY: next-version
-next-version: check-npx
-	npx standard-version --dry-run
-
-.PHONY: check-npx
-check-npx:
-	$(if $(shell which npx),,\
-		$(error No npx found in PATH, please install NodeJS))

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/jimeh/rands
 
-go 1.15
+go 1.17
 
 require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/ints.go
+++ b/ints.go
@@ -8,13 +8,13 @@ import (
 
 var ErrInvalidMaxInt = fmt.Errorf("%w: max cannot be less than 1", Err)
 
-// Int generates a random int ranging between 0 and max.
-func Int(max int) (int, error) {
-	if max < 1 {
+// Int generates a random int ranging between 0 and nMax.
+func Int(nMax int) (int, error) {
+	if nMax < 1 {
 		return 0, ErrInvalidMaxInt
 	}
 
-	r, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+	r, err := rand.Int(rand.Reader, big.NewInt(int64(nMax)))
 	if err != nil {
 		return 0, err
 	}
@@ -22,13 +22,13 @@ func Int(max int) (int, error) {
 	return int(r.Int64()), nil
 }
 
-// Int64 generates a random int64 ranging between 0 and max.
-func Int64(max int64) (int64, error) {
-	if max < 1 {
+// Int64 generates a random int64 ranging between 0 and nMax.
+func Int64(nMax int64) (int64, error) {
+	if nMax < 1 {
 		return 0, ErrInvalidMaxInt
 	}
 
-	r, err := rand.Int(rand.Reader, big.NewInt(max))
+	r, err := rand.Int(rand.Reader, big.NewInt(nMax))
 	if err != nil {
 		return 0, err
 	}

--- a/randsmust/ints.go
+++ b/randsmust/ints.go
@@ -2,9 +2,9 @@ package randsmust
 
 import "github.com/jimeh/rands"
 
-// Int generates a random int ranging between 0 and max.
-func Int(max int) int {
-	r, err := rands.Int(max)
+// Int generates a random int ranging between 0 and nMax.
+func Int(nMax int) int {
+	r, err := rands.Int(nMax)
 	if err != nil {
 		panic(err)
 	}
@@ -12,9 +12,9 @@ func Int(max int) int {
 	return r
 }
 
-// Int64 generates a random int64 ranging between 0 and max.
-func Int64(max int64) int64 {
-	r, err := rands.Int64(max)
+// Int64 generates a random int64 ranging between 0 and nMax.
+func Int64(nMax int64) int64 {
+	r, err := rands.Int64(nMax)
 	if err != nil {
 		panic(err)
 	}

--- a/randsmust/strings.go
+++ b/randsmust/strings.go
@@ -165,12 +165,12 @@ func UnicodeString(n int, alphabet []rune) string {
 //
 // In summary, the generated random string will:
 //
-//  - be between 1 and 63 characters in length, other n values returns a error
-//  - first character will be one of a-z
-//  - last character will be one of a-z or 0-9
-//  - in-between first and last characters consist of a-z, 0-9, or "-"
-//  - potentially contain two or more consecutive "-", except the 3rd and 4th
-//    characters, as that would violate RFC 5891, section 4.2.3.1.
+//   - be between 1 and 63 characters in length, other n values returns a error
+//   - first character will be one of a-z
+//   - last character will be one of a-z or 0-9
+//   - in-between first and last characters consist of a-z, 0-9, or "-"
+//   - potentially contain two or more consecutive "-", except the 3rd and 4th
+//     characters, as that would violate RFC 5891, section 4.2.3.1.
 func DNSLabel(n int) string {
 	r, err := rands.DNSLabel(n)
 	if err != nil {

--- a/strings.go
+++ b/strings.go
@@ -171,12 +171,12 @@ func UnicodeString(n int, alphabet []rune) (string, error) {
 //
 // In summary, the generated random string will:
 //
-//  - be between 1 and 63 characters in length, other n values returns a error
-//  - first character will be one of a-z
-//  - last character will be one of a-z or 0-9
-//  - in-between first and last characters consist of a-z, 0-9, or "-"
-//  - potentially contain two or more consecutive "-", except the 3rd and 4th
-//    characters, as that would violate RFC 5891, section 4.2.3.1.
+//   - be between 1 and 63 characters in length, other n values returns a error
+//   - first character will be one of a-z
+//   - last character will be one of a-z or 0-9
+//   - in-between first and last characters consist of a-z, 0-9, or "-"
+//   - potentially contain two or more consecutive "-", except the 3rd and 4th
+//     characters, as that would violate RFC 5891, section 4.2.3.1.
 func DNSLabel(n int) (string, error) {
 	switch {
 	case n < 1 || n > 63:


### PR DESCRIPTION
Upgrade to Go 1.17 and golangci-lint to 1.64, and fix the linting issues that
were found.

Also upgrade CI workflow actions to latest versions, and setup a test matrix for
relevant Go versions.

BREAKING CHANGE: Minimum Go version changed from 1.15 to 1.17.